### PR TITLE
Name HDF5 slice groups after the compared parameters

### DIFF
--- a/docs/how_to/use_this_plugin.md
+++ b/docs/how_to/use_this_plugin.md
@@ -20,9 +20,12 @@ same run. The parser creates two entries:
 
 Each 2D slice of the parameter space is stored as an HDF5 group named after the
 two parameters it compares (e.g. `phi_vs_psi`), so the H5Web tree reflects what
-is plotted. When names are edited, the groups are renamed to match. The axis
-labels of the H5Web plots come from the `parameter_names` field of the BOSS
-Analysis entry. They can be set in three ways, in order of precedence:
+is plotted. The order is meaningful: the first name is the parameter on the
+x-axis and the second is on the y-axis (`phi_vs_psi` puts `phi` on x, `psi` on
+y), following the parameter order of the run. When names are edited, the groups
+are renamed to match. The axis labels of the H5Web plots come from the
+`parameter_names` field of the BOSS Analysis entry. They can be set in three
+ways, in order of precedence:
 
 1. **Edited in the ELN**: change `parameter_names` on the BOSS Analysis entry
    and save. The plot labels and titles update immediately; the fits are not

--- a/docs/how_to/use_this_plugin.md
+++ b/docs/how_to/use_this_plugin.md
@@ -18,8 +18,11 @@ same run. The parser creates two entries:
 
 ## Parameter Names and Plot Labels
 
-The axis labels of the H5Web plots come from the `parameter_names` field of the
-BOSS Analysis entry. They can be set in three ways, in order of precedence:
+Each 2D slice of the parameter space is stored as an HDF5 group named after the
+two parameters it compares (e.g. `phi_vs_psi`), so the H5Web tree reflects what
+is plotted. When names are edited, the groups are renamed to match. The axis
+labels of the H5Web plots come from the `parameter_names` field of the BOSS
+Analysis entry. They can be set in three ways, in order of precedence:
 
 1. **Edited in the ELN**: change `parameter_names` on the BOSS Analysis entry
    and save. The plot labels and titles update immediately; the fits are not

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -49,9 +49,18 @@ def slice_group_names(parameter_names: list[str]) -> list[str]:
     Names of the HDF5 groups holding each 2D parameter-space slice, one per
     ``(i, j)`` index pair from `generate_slices` and in that order. Each group
     is named ``'{x}_vs_{y}'`` after the compared parameters so the H5Web tree
-    reflects what is plotted. A slice whose names do not yield a usable
-    component falls back to ``'slice_{index}'``, and any name that would still
-    collide is disambiguated, so the returned list is always unique.
+    reflects what is plotted.
+
+    The order of the two names is significant: ``x`` is the lower-index
+    parameter, shown on the ``parameters_x`` axis, and ``y`` is the
+    higher-index parameter, shown on ``parameters_y``. So ``'a_vs_b'`` and
+    ``'b_vs_a'`` denote different axis assignments and only the former is
+    produced (``generate_slices`` always yields ``i < j``).
+
+    A slice whose names do not yield a usable component falls back to
+    ``'slice_{index}'``, and any name that would still collide (e.g. from
+    duplicate parameter names) is disambiguated, so the returned list is
+    always unique.
     """
     names = list(parameter_names)
     proposed = []

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -280,10 +280,20 @@ class PotentialEnergySurfaceFit(Schema):
         with archive.m_context.raw_file(self.auxiliary_file) as file_handle:
             h5_path = file_handle.name
         with h5py.File(h5_path, 'r+') as h5:
-            for old_group, new_group in renames.items():
-                old_key, new_key = old_group.lstrip('/'), new_group.lstrip('/')
-                if old_key in h5 and new_key not in h5:
-                    h5.move(old_key, new_key)
+            # Two-phase move: park every source under a unique temporary name,
+            # then move each temporary to its destination. A direct old->new
+            # move would skip any rename whose destination is still occupied by
+            # another group, silently corrupting permutation/cyclic renames
+            # (e.g. /a_vs_b and /a_vs_c swapping).
+            parked: list[tuple[str, str]] = []
+            for index, (old_group, new_group) in enumerate(renames.items()):
+                old_key = old_group.lstrip('/')
+                if old_key in h5:
+                    temporary_key = f'__rename_tmp_{index}__'
+                    h5.move(old_key, temporary_key)
+                    parked.append((temporary_key, new_group.lstrip('/')))
+            for temporary_key, new_key in parked:
+                h5.move(temporary_key, new_key)
 
         for parameter_slice, dataset, new_reference in reference_updates:
             setattr(parameter_slice, dataset, new_reference)

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -244,7 +244,9 @@ class PotentialEnergySurfaceFit(Schema):
             )
             return
 
-        self._rename_slice_groups(archive, slice_group_names(self.parameter_names))
+        self._rename_slice_groups(
+            archive, slice_group_names(self.parameter_names), logger
+        )
 
         handler = HDF5Handler(
             filename=self.auxiliary_file, archive=archive, logger=logger
@@ -254,17 +256,19 @@ class PotentialEnergySurfaceFit(Schema):
         handler.write_file()
 
     def _rename_slice_groups(
-        self, archive: 'EntryArchive', group_names: list[str]
+        self, archive: 'EntryArchive', group_names: list[str], logger: 'BoundLogger'
     ) -> None:
         """
         Rename the HDF5 slice groups to `group_names` and rewrite the affected
         `HDF5Reference` values. The rename is a metadata-only `h5py` move (no
         data copy); groups whose name is already correct are left untouched.
+        References are only rewritten for groups that are actually moved, so a
+        source group missing from the file cannot leave a reference dangling.
         """
         import h5py
 
-        renames: dict[str, str] = {}
-        reference_updates: list[tuple[ParameterSpaceSlice, str, str]] = []
+        # Plan the renames: current group -> (new group, its reference updates)
+        plans: dict[str, tuple[str, list[tuple[ParameterSpaceSlice, str, str]]]] = {}
         for group_name, parameter_slice in zip(group_names, self.parameter_slices):
             reference = parameter_slice.fit
             if not reference or '#' not in reference:
@@ -273,38 +277,53 @@ class PotentialEnergySurfaceFit(Schema):
             new_group = f'/{group_name}'
             if current_group == new_group:
                 continue
-            renames[current_group] = new_group
+            updates = []
             for dataset in SLICE_DATASETS:
                 dataset_reference = getattr(parameter_slice, dataset)
                 if dataset_reference and '#' in dataset_reference:
                     prefix = dataset_reference.split('#', 1)[0]
-                    reference_updates.append(
+                    updates.append(
                         (parameter_slice, dataset, f'{prefix}#{new_group}/{dataset}')
                     )
+            plans[current_group] = (new_group, updates)
 
-        if not renames:
+        if not plans:
             return
 
         # Resolve the on-disk path; only `.name` is used, so open mode is moot
         with archive.m_context.raw_file(self.auxiliary_file) as file_handle:
             h5_path = file_handle.name
+
+        applied_updates: list[tuple[ParameterSpaceSlice, str, str]] = []
         with h5py.File(h5_path, 'r+') as h5:
             # Two-phase move: park every source under a unique temporary name,
             # then move each temporary to its destination. A direct old->new
             # move would skip any rename whose destination is still occupied by
             # another group, silently corrupting permutation/cyclic renames
             # (e.g. /a_vs_b and /a_vs_c swapping).
-            parked: list[tuple[str, str]] = []
-            for index, (old_group, new_group) in enumerate(renames.items()):
-                old_key = old_group.lstrip('/')
-                if old_key in h5:
-                    temporary_key = f'__rename_tmp_{index}__'
-                    h5.move(old_key, temporary_key)
-                    parked.append((temporary_key, new_group.lstrip('/')))
-            for temporary_key, new_key in parked:
+            parked: list[tuple[str, str, list[tuple[ParameterSpaceSlice, str, str]]]]
+            parked = []
+            for index, (current_group, (new_group, updates)) in enumerate(
+                plans.items()
+            ):
+                old_key = current_group.lstrip('/')
+                if old_key not in h5:
+                    logger.warning(
+                        'Slice group missing from the auxiliary file; leaving '
+                        'its references unchanged.',
+                        group=current_group,
+                        file=self.auxiliary_file,
+                    )
+                    continue
+                temporary_key = f'__rename_tmp_{index}__'
+                h5.move(old_key, temporary_key)
+                parked.append((temporary_key, new_group.lstrip('/'), updates))
+            for temporary_key, new_key, updates in parked:
                 h5.move(temporary_key, new_key)
+                applied_updates.extend(updates)
 
-        for parameter_slice, dataset, new_reference in reference_updates:
+        # Only rewrite references for groups whose data was actually moved
+        for parameter_slice, dataset, new_reference in applied_updates:
             setattr(parameter_slice, dataset, new_reference)
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -1,3 +1,5 @@
+import re
+from collections import Counter
 from collections.abc import Generator
 from typing import TYPE_CHECKING
 
@@ -21,12 +23,53 @@ if TYPE_CHECKING:
 
 m_package = SchemaPackage()
 
+# Datasets written per slice group, in the order H5Web expects them.
+SLICE_DATASETS = ('fit', 'uncertainty', 'iteration', 'parameters_x', 'parameters_y')
+
 
 def generate_slices(ranks: int) -> Generator:
     """Produce all possible index pairs defining slices of the parameter space."""
     for main_rank in range(ranks):
         for upper_rank in range(main_rank + 1, ranks):
             yield main_rank, upper_rank
+
+
+def sanitize_h5_name(name: str) -> str:
+    """
+    Make a parameter name safe as an HDF5 path component: collapse the path
+    separator ``/``, the reference-fragment marker ``#``, and whitespace runs
+    into single underscores. May return ``''`` for a name with no usable
+    characters (e.g. ``'/'`` or ``'   '``).
+    """
+    return re.sub(r'[\s/#]+', '_', name).strip('_')
+
+
+def slice_group_names(parameter_names: list[str]) -> list[str]:
+    """
+    Names of the HDF5 groups holding each 2D parameter-space slice, one per
+    ``(i, j)`` index pair from `generate_slices` and in that order. Each group
+    is named ``'{x}_vs_{y}'`` after the compared parameters so the H5Web tree
+    reflects what is plotted. A slice whose names do not yield a usable
+    component falls back to ``'slice_{index}'``, and any name that would still
+    collide is disambiguated, so the returned list is always unique.
+    """
+    names = list(parameter_names)
+    proposed = []
+    for index, (main_rank, upper_rank) in enumerate(generate_slices(len(names))):
+        x = sanitize_h5_name(names[main_rank])
+        y = sanitize_h5_name(names[upper_rank])
+        proposed.append(f'{x}_vs_{y}' if x and y else f'slice_{index}')
+
+    counts = Counter(proposed)
+    used: set[str] = set()
+    result: list[str] = []
+    for index, name in enumerate(proposed):
+        unique_name = f'{name}_{index}' if counts[name] > 1 else name
+        while unique_name in used:
+            unique_name = f'{unique_name}_dup'
+        used.add(unique_name)
+        result.append(unique_name)
+    return result
 
 
 def h5web_attribute_map(parameter_names: list[str]) -> dict[str, dict]:
@@ -36,9 +79,12 @@ def h5web_attribute_map(parameter_names: list[str]) -> dict[str, dict]:
     Axis labels come from the `long_name` attribute of the axis datasets.
     """
     names = list(parameter_names)
+    group_names = slice_group_names(names)
     attribute_map = {}
-    for counter, (main_rank, upper_rank) in enumerate(generate_slices(len(names))):
-        prefix = f'/slice_{counter}'
+    for group_name, (main_rank, upper_rank) in zip(
+        group_names, generate_slices(len(names))
+    ):
+        prefix = f'/{group_name}'
         attribute_map[prefix] = dict(
             NX_class='NXdata',
             signal='fit',
@@ -166,9 +212,10 @@ class PotentialEnergySurfaceFit(Schema):
         self, archive: 'EntryArchive', logger: 'BoundLogger'
     ) -> None:
         """
-        Write the current `parameter_names` as NeXus attributes into the auxiliary
-        HDF5 file. Runs on every normalization, so ELN edits of `parameter_names`
-        update the H5Web axis labels without recomputing the fits.
+        Reconcile the auxiliary HDF5 file with the current `parameter_names`.
+        Runs on every normalization, so ELN edits of `parameter_names` rename the
+        slice groups after the compared parameters and update the H5Web axis
+        labels without recomputing the fits.
         """
         if not self.parameter_names or not self.auxiliary_file:
             return
@@ -188,12 +235,58 @@ class PotentialEnergySurfaceFit(Schema):
             )
             return
 
+        self._rename_slice_groups(archive, slice_group_names(self.parameter_names))
+
         handler = HDF5Handler(
             filename=self.auxiliary_file, archive=archive, logger=logger
         )
         for path, attributes in h5web_attribute_map(self.parameter_names).items():
             handler.add_attribute(path=path, params=attributes)
         handler.write_file()
+
+    def _rename_slice_groups(
+        self, archive: 'EntryArchive', group_names: list[str]
+    ) -> None:
+        """
+        Rename the HDF5 slice groups to `group_names` and rewrite the affected
+        `HDF5Reference` values. The rename is a metadata-only `h5py` move (no
+        data copy); groups whose name is already correct are left untouched.
+        """
+        import h5py
+
+        renames: dict[str, str] = {}
+        reference_updates: list[tuple[ParameterSpaceSlice, str, str]] = []
+        for group_name, parameter_slice in zip(group_names, self.parameter_slices):
+            reference = parameter_slice.fit
+            if not reference or '#' not in reference:
+                continue
+            current_group = reference.split('#', 1)[1].rsplit('/', 1)[0]
+            new_group = f'/{group_name}'
+            if current_group == new_group:
+                continue
+            renames[current_group] = new_group
+            for dataset in SLICE_DATASETS:
+                dataset_reference = getattr(parameter_slice, dataset)
+                if dataset_reference and '#' in dataset_reference:
+                    prefix = dataset_reference.split('#', 1)[0]
+                    reference_updates.append(
+                        (parameter_slice, dataset, f'{prefix}#{new_group}/{dataset}')
+                    )
+
+        if not renames:
+            return
+
+        # Resolve the on-disk path; only `.name` is used, so open mode is moot
+        with archive.m_context.raw_file(self.auxiliary_file) as file_handle:
+            h5_path = file_handle.name
+        with h5py.File(h5_path, 'r+') as h5:
+            for old_group, new_group in renames.items():
+                old_key, new_key = old_group.lstrip('/'), new_group.lstrip('/')
+                if old_key in h5 and new_key not in h5:
+                    h5.move(old_key, new_key)
+
+        for parameter_slice, dataset, new_reference in reference_updates:
+            setattr(parameter_slice, dataset, new_reference)
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         super().normalize(archive, logger)
@@ -303,6 +396,13 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
 
         h5_filename = f'{self.data_file.rsplit(".", 1)[0]}.h5'
         self.auxiliary_file = h5_filename
+        # Start from a clean file: a recomputation over an existing .h5 would
+        # otherwise leave stale groups behind (e.g. slices named under a
+        # previous set of parameter names)
+        if archive.m_context.raw_path_exists(h5_filename):
+            with archive.m_context.raw_file(h5_filename, 'rb') as existing:
+                existing_path = existing.name
+            os.remove(existing_path)
         handler = HDF5Handler(filename=h5_filename, archive=archive, logger=logger)
 
         iteration_procedure = np.arange(iter_no, 0, -1)
@@ -310,8 +410,10 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
         # All parameters not in the slice are fixed to the global-minimum point
         x_default = np.atleast_2d(res.select('x_glmin', iter_no))
 
+        group_names = slice_group_names(self.parameter_names)
         for parameter_counter, rank in enumerate(generate_slices(len(bounds))):
             main_rank, upper_rank = rank
+            group = group_names[parameter_counter]
             mu_all_slices, var_all_slices = [], []
 
             # Query points on the 2D slice grid, built directly instead of via
@@ -331,53 +433,21 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
 
             self.parameter_slices.append(ParameterSpaceSlice())
 
-            handler.add_dataset(
-                path=f'/slice_{parameter_counter}/fit',
-                dataset=Dataset(
-                    data=np.array(mu_all_slices),
-                    archive_path=f'data.parameter_slices[{parameter_counter}].fit',
-                ),
-            )
-
-            handler.add_dataset(
-                path=f'/slice_{parameter_counter}/uncertainty',
-                dataset=Dataset(
-                    data=np.sqrt(np.array(var_all_slices)),
-                    archive_path=(
-                        f'data.parameter_slices[{parameter_counter}].uncertainty'
+            archive_prefix = f'data.parameter_slices[{parameter_counter}]'
+            for dataset, data in (
+                ('fit', np.array(mu_all_slices)),
+                ('uncertainty', np.sqrt(np.array(var_all_slices))),
+                ('iteration', iteration_procedure),
+                ('parameters_x', np.array(compute_parameters(main_rank))),
+                ('parameters_y', np.array(compute_parameters(upper_rank))),
+            ):
+                handler.add_dataset(
+                    path=f'/{group}/{dataset}',
+                    dataset=Dataset(
+                        data=data,
+                        archive_path=f'{archive_prefix}.{dataset}',
                     ),
-                ),
-            )
-
-            handler.add_dataset(
-                path=f'/slice_{parameter_counter}/iteration',
-                dataset=Dataset(
-                    data=iteration_procedure,
-                    archive_path=(
-                        f'data.parameter_slices[{parameter_counter}].iteration'
-                    ),
-                ),
-            )
-
-            handler.add_dataset(
-                path=f'/slice_{parameter_counter}/parameters_x',
-                dataset=Dataset(
-                    data=np.array(compute_parameters(main_rank)),
-                    archive_path=(
-                        f'data.parameter_slices[{parameter_counter}].parameters_x'
-                    ),
-                ),
-            )
-
-            handler.add_dataset(
-                path=f'/slice_{parameter_counter}/parameters_y',
-                dataset=Dataset(
-                    data=np.array(compute_parameters(upper_rank)),
-                    archive_path=(
-                        f'data.parameter_slices[{parameter_counter}].parameters_y'
-                    ),
-                ),
-            )
+                )
 
         for path, attributes in h5web_attribute_map(self.parameter_names).items():
             handler.add_attribute(path=path, params=attributes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -12,8 +13,8 @@ from structlog.testing import LogCapture
 from nomad_parser_plugin_boss.schema_packages.schema_package import (
     ELNBOSSAnalysis,
     ParameterSpaceSlice,
-    generate_slices,
     h5web_attribute_map,
+    slice_group_names,
 )
 
 DATA_DIR = Path(__file__).parent / 'data'
@@ -75,11 +76,17 @@ def synthetic_compute_pes(self, archive, logger):
     if not self.parameter_names:
         self.parameter_names = ['parameter_0', 'parameter_1']
     self.auxiliary_file = f'{self.data_file.rsplit(".", 1)[0]}.h5'
+    # Mirror the real _compute_pes: start from a clean file so stale groups
+    # from a previous computation do not linger
+    if archive.m_context.raw_path_exists(self.auxiliary_file):
+        with archive.m_context.raw_file(self.auxiliary_file, 'rb') as existing:
+            existing_path = existing.name
+        os.remove(existing_path)
     handler = HDF5Handler(filename=self.auxiliary_file, archive=archive, logger=logger)
 
     iterations = np.arange(2, 0, -1)
     grid = np.linspace(0.0, 1.0, num=5)
-    for counter, _ in enumerate(generate_slices(len(self.parameter_names))):
+    for counter, group in enumerate(slice_group_names(self.parameter_names)):
         self.parameter_slices.append(ParameterSpaceSlice())
         values = np.full((len(iterations), 5, 5), float(counter))
         for name, data in (
@@ -90,7 +97,7 @@ def synthetic_compute_pes(self, archive, logger):
             ('parameters_y', grid),
         ):
             handler.add_dataset(
-                path=f'/slice_{counter}/{name}',
+                path=f'/{group}/{name}',
                 dataset=Dataset(
                     data=data,
                     archive_path=f'data.parameter_slices[{counter}].{name}',

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -238,6 +238,53 @@ def test_eln_edit_renames_group_and_refreshes_labels(
         assert np.array_equal(h5file['/alpha_vs_beta/fit'][()], fit_before)
 
 
+def test_eln_edit_permutation_preserves_data(upload_dir, synthetic_pes, monkeypatch):
+    """
+    A name edit that permutes the pairwise group names (e.g. swapping the labels
+    of two parameters) makes group names cycle. The rename must move the groups
+    consistently, so every slice still resolves to its own data rather than
+    another slice's. On the direct-move code this cycle silently swapped the data.
+    """
+    mainfile = upload_dir / 'three.archive.yaml'
+    mainfile.write_text(
+        'data:\n'
+        '  m_def: nomad_parser_plugin_boss.schema_packages.schema_package'
+        '.ELNBOSSAnalysis\n'
+        '  data_file: boss.rst\n'
+        '  parameter_names:\n    - a\n    - b\n    - c\n'
+    )
+    archive = parse(str(mainfile))[0]
+    normalize_all(archive)
+
+    # the synthetic _compute_pes writes float(counter) into each slice's fit;
+    # resolve each slice's value through its own reference
+    def fit_value(parameter_slice, h5file):
+        group = parameter_slice.fit.rsplit('#', 1)[1].rsplit('/', 1)[0].lstrip('/')
+        return h5file[f'{group}/fit'][0, 0, 0]
+
+    with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
+        before = [fit_value(s, h5file) for s in archive.data.parameter_slices]
+    assert before == [0.0, 1.0, 2.0]
+
+    # swap the labels of parameters 1 and 2: a_vs_b <-> a_vs_c cycle
+    edited = archive.data.m_to_dict(with_root_def=True)
+    edited['parameter_names'] = ['a', 'c', 'b']
+    edited_file = upload_dir / 'three.archive.json'
+    edited_file.write_text(json.dumps({'data': edited}))
+
+    def fail_compute(self, archive, logger):
+        pytest.fail('The expensive BOSS compute must not run on an ELN edit')
+
+    monkeypatch.setattr(ELNBOSSAnalysis, '_compute_pes', fail_compute)
+
+    edited_archive = parse(str(edited_file))[0]
+    normalize_all(edited_archive)
+
+    with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
+        after = [fit_value(s, h5file) for s in edited_archive.data.parameter_slices]
+    assert after == before  # each slice kept its own data through the cycle
+
+
 def test_recompute_clears_stale_groups(upload_dir, synthetic_pes):
     """
     A recomputation over an existing .h5 (e.g. after the analysis entry lost

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -297,6 +297,39 @@ def test_eln_edit_permutation_preserves_data(upload_dir, synthetic_pes, monkeypa
     assert after == before  # each slice kept its own data through the cycle
 
 
+def test_rename_leaves_missing_group_reference_untouched(
+    upload_dir, synthetic_pes, monkeypatch
+):
+    """
+    If a slice's referenced group is absent from the auxiliary file, the rename
+    must not point that reference at a destination it never created: the move is
+    skipped and the reference is left as-is (with a warning).
+    """
+    archive = parse(str(upload_dir / 'test.archive.yaml'))[0]  # names x, y
+    normalize_all(archive)
+
+    # drop the group from the file, leaving the archive reference dangling
+    with h5py.File(upload_dir / 'boss.h5', 'r+') as h5file:
+        del h5file['x_vs_y']
+
+    edited = archive.data.m_to_dict(with_root_def=True)
+    edited['parameter_names'] = ['alpha', 'beta']
+    edited_file = upload_dir / 'boss.archive.json'
+    edited_file.write_text(json.dumps({'data': edited}))
+
+    def fail_compute(self, archive, logger):
+        pytest.fail('The expensive BOSS compute must not run on an ELN edit')
+
+    monkeypatch.setattr(ELNBOSSAnalysis, '_compute_pes', fail_compute)
+
+    edited_archive = parse(str(edited_file))[0]
+    normalize_all(edited_archive)
+
+    # the reference was not rewritten to the non-existent /alpha_vs_beta group
+    fit_reference = edited_archive.data.parameter_slices[0].fit
+    assert fit_reference.rsplit('#', 1)[-1] == '/x_vs_y/fit'
+
+
 def test_recompute_clears_stale_groups(upload_dir, synthetic_pes):
     """
     A recomputation over an existing .h5 (e.g. after the analysis entry lost

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -1,4 +1,5 @@
 import json
+import re
 from itertools import combinations
 
 import h5py
@@ -11,6 +12,8 @@ from nomad.client import normalize_all, parse
 from nomad_parser_plugin_boss.schema_packages.schema_package import (
     ELNBOSSAnalysis,
     h5web_attribute_map,
+    sanitize_h5_name,
+    slice_group_names,
 )
 
 parameter_names = st.lists(
@@ -18,28 +21,77 @@ parameter_names = st.lists(
 )
 
 
+def test_sanitize_h5_name():
+    # path separator, reference marker and whitespace runs collapse to '_'
+    assert sanitize_h5_name('phi') == 'phi'
+    assert sanitize_h5_name('a/b') == 'a_b'
+    assert sanitize_h5_name('a#b') == 'a_b'
+    assert sanitize_h5_name('spin  up') == 'spin_up'
+    assert sanitize_h5_name(' theta ') == 'theta'
+    # names with no usable characters collapse to empty
+    assert sanitize_h5_name('/') == ''
+    assert sanitize_h5_name('   ') == ''
+
+
+def test_slice_group_names():
+    # groups are named after the compared parameters, in generate_slices order
+    assert slice_group_names(['a', 'b', 'c']) == ['a_vs_b', 'a_vs_c', 'b_vs_c']
+    # a name that sanitizes to empty falls back to the indexed slice name
+    assert slice_group_names(['/', 'b']) == ['slice_0']
+    # names that sanitize to the same component would collide, so the
+    # duplicated group names are disambiguated with the slice index
+    assert slice_group_names(['x/y', 'x#y', 'z']) == [
+        'x_y_vs_x_y',
+        'x_y_vs_z_1',
+        'x_y_vs_z_2',
+    ]
+
+
 def test_h5web_attribute_map():
     attribute_map = h5web_attribute_map(['a', 'b', 'c'])
 
     # C(3, 2) = 3 slices, pairing follows generate_slices: (a,b), (a,c), (b,c)
     assert [key for key in attribute_map if key.count('/') == 1] == [
-        '/slice_0',
-        '/slice_1',
-        '/slice_2',
+        '/a_vs_b',
+        '/a_vs_c',
+        '/b_vs_c',
     ]
-    assert attribute_map['/slice_0']['title'] == 'a vs b'
-    assert attribute_map['/slice_1']['title'] == 'a vs c'
-    assert attribute_map['/slice_2/parameters_x']['long_name'] == 'b'
-    assert attribute_map['/slice_2/parameters_y']['long_name'] == 'c'
+    assert attribute_map['/a_vs_b']['title'] == 'a vs b'
+    assert attribute_map['/a_vs_c']['title'] == 'a vs c'
+    assert attribute_map['/b_vs_c/parameters_x']['long_name'] == 'b'
+    assert attribute_map['/b_vs_c/parameters_y']['long_name'] == 'c'
 
     # The fixed NeXus constants are asserted here, example-based, exactly once
-    group_attrs = attribute_map['/slice_0']
+    group_attrs = attribute_map['/a_vs_b']
     assert group_attrs['NX_class'] == 'NXdata'
     assert group_attrs['signal'] == 'fit'
     assert group_attrs['axes'] == ['iteration', 'parameters_x', 'parameters_y']
     assert group_attrs['auxiliary_signals'] == ['uncertainty']
-    assert attribute_map['/slice_0/fit']['units'] == 'eV'
-    assert attribute_map['/slice_0/uncertainty']['units'] == 'eV'
+    assert attribute_map['/a_vs_b/fit']['units'] == 'eV'
+    assert attribute_map['/a_vs_b/uncertainty']['units'] == 'eV'
+
+
+@given(names=parameter_names)
+def test_slice_group_names_properties(names):
+    """
+    Hypothesis property test for `slice_group_names` over arbitrary lists of
+    2-8 unique names.
+
+    Predicates, for `names` of length n:
+      G1: exactly C(n,2) group names are produced.
+      G2: every group name is HDF5-path-safe: non-empty and free of '/',
+          '#', and whitespace (they are used directly as path components).
+      G3: the group names are unique (no two slices share a group), which
+          adversarial sanitization collisions must not violate.
+    """
+    group_names = slice_group_names(names)
+    n = len(names)
+
+    assert len(group_names) == n * (n - 1) // 2  # G1
+    for group_name in group_names:
+        assert group_name  # G2
+        assert not re.search(r'[\s/#]', group_name)  # G2
+    assert len(set(group_names)) == len(group_names)  # G3
 
 
 @given(names=parameter_names)
@@ -50,12 +102,13 @@ def test_h5web_attribute_map_properties(names):
     constants are covered once in the example-based test above.
 
     Predicates, for `names` of length n:
-      P1: the map contains exactly C(n,2) group paths, named
-          /slice_0 .. /slice_{C(n,2)-1} in that order.
+      P1: the map contains exactly C(n,2) group paths, one per slice group
+          from `slice_group_names`, in that order.
       P2: the (parameters_x, parameters_y) long_name pairs of the groups
           enumerate every index pair (i, j) with i < j exactly once, in
           generate_slices order — checked against the independent oracle
-          itertools.combinations.
+          itertools.combinations. long_names carry the original (unsanitized)
+          names, so the lookup is exact.
       P3 (relational): each group's title agrees with its own axis
           long_names: title == f'{x} vs {y}'.
       P4: every group carries attribute entries for all five datasets
@@ -65,7 +118,7 @@ def test_h5web_attribute_map_properties(names):
 
     groups = [key for key in attribute_map if key.count('/') == 1]
     n = len(names)
-    assert groups == [f'/slice_{i}' for i in range(n * (n - 1) // 2)]
+    assert groups == [f'/{group}' for group in slice_group_names(names)]  # P1
 
     axis_pairs = []
     for group in groups:
@@ -84,12 +137,16 @@ def test_h5web_attribute_map_properties(names):
 def test_h5web_attribute_map_rename_metamorphic(names):
     """
     Hypothesis metamorphic property: applying a bijective rename to the
-    input names must change exactly the name-derived attribute values and
-    nothing else.
+    input names must transform exactly the name-derived values (group paths,
+    axis long_names, titles) and leave every other attribute untouched.
 
-    Predicates, comparing map(names) with map(renamed) where
-    renamed[i] = names[i] + suffix (a bijection by construction):
-      M1: the set of attribute paths is identical.
+    The rename appends '~renamed' to each name. Because group paths now
+    encode the parameter names, the two maps have different keys but the same
+    structure, so entries are compared position-by-position.
+
+    Predicates, comparing map(names) with map(renamed):
+      M1: both maps have the same number of entries and each aligned pair
+          sits at the same structural depth (group vs dataset).
       M2: axis dataset long_names transform by exactly the rename mapping.
       M3: group titles remain consistent with their own (renamed) axis
           long_names; all other group attributes are unchanged.
@@ -100,13 +157,15 @@ def test_h5web_attribute_map_rename_metamorphic(names):
     original = h5web_attribute_map(names)
     transformed = h5web_attribute_map(renamed)
 
-    assert original.keys() == transformed.keys()  # M1
-    for path, attrs in original.items():
-        renamed_attrs = transformed[path]
+    assert len(original) == len(transformed)  # M1
+    for (path, attrs), (renamed_path, renamed_attrs) in zip(
+        original.items(), transformed.items()
+    ):
+        assert path.count('/') == renamed_path.count('/')  # M1
         assert attrs.keys() == renamed_attrs.keys()
-        if path.count('/') == 1:  # group
-            x_name = transformed[f'{path}/parameters_x']['long_name']
-            y_name = transformed[f'{path}/parameters_y']['long_name']
+        if path.count('/') == 1:  # group node
+            x_name = transformed[f'{renamed_path}/parameters_x']['long_name']
+            y_name = transformed[f'{renamed_path}/parameters_y']['long_name']
             assert renamed_attrs['title'] == f'{x_name} vs {y_name}'  # M3
             assert {k: v for k, v in renamed_attrs.items() if k != 'title'} == {
                 k: v for k, v in attrs.items() if k != 'title'
@@ -125,30 +184,31 @@ def test_first_pass_labels(upload_dir, synthetic_pes, assert_h5web_group):
     assert data.auxiliary_file == 'boss.h5'
     fit_reference = data.parameter_slices[0].fit
     assert fit_reference.startswith('/uploads/')
-    assert fit_reference.rsplit('#', 1)[-1] == '/slice_0/fit'
+    assert fit_reference.rsplit('#', 1)[-1] == '/x_vs_y/fit'
 
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
         assert_h5web_group(
             h5file,
-            '/slice_0',
+            '/x_vs_y',
             title='x vs y',
             long_names={'parameters_x': 'x', 'parameters_y': 'y'},
         )
 
 
-def test_eln_edit_refreshes_labels(
+def test_eln_edit_renames_group_and_refreshes_labels(
     upload_dir, synthetic_pes, assert_h5web_group, monkeypatch
 ):
     """
     Replicate the editable-archive flow: a GUI edit rewrites the .archive.json
-    and re-runs normalization (no parser). The labels in the auxiliary HDF5 file
-    must follow the edited parameter_names without recomputing the fits.
+    and re-runs normalization (no parser). The slice group is renamed after the
+    edited parameter_names and the labels follow, without recomputing the fits:
+    the group is moved (data preserved) and the HDF5References are rewritten.
     """
     archive = parse(str(upload_dir / 'test.archive.yaml'))[0]
     normalize_all(archive)
 
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
-        fit_before = h5file['/slice_0/fit'][()]
+        fit_before = h5file['/x_vs_y/fit'][()]
 
     edited_data = archive.data.m_to_dict(with_root_def=True)
     edited_data['parameter_names'] = ['alpha', 'beta']
@@ -163,14 +223,45 @@ def test_eln_edit_refreshes_labels(
     edited_archive = parse(str(edited_file))[0]
     normalize_all(edited_archive)
 
+    # the HDF5Reference now points at the renamed group
+    fit_reference = edited_archive.data.parameter_slices[0].fit
+    assert fit_reference.rsplit('#', 1)[-1] == '/alpha_vs_beta/fit'
+
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
+        assert '/x_vs_y' not in h5file  # group was moved, not copied
         assert_h5web_group(
             h5file,
-            '/slice_0',
+            '/alpha_vs_beta',
             title='alpha vs beta',
             long_names={'parameters_x': 'alpha', 'parameters_y': 'beta'},
         )
-        assert np.array_equal(h5file['/slice_0/fit'][()], fit_before)
+        assert np.array_equal(h5file['/alpha_vs_beta/fit'][()], fit_before)
+
+
+def test_recompute_clears_stale_groups(upload_dir, synthetic_pes):
+    """
+    A recomputation over an existing .h5 (e.g. after the analysis entry lost
+    its computed slices) must rebuild a clean file, not leave the previously
+    named group behind.
+    """
+    archive = parse(str(upload_dir / 'test.archive.yaml'))[0]  # names x, y
+    normalize_all(archive)
+    with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
+        assert set(h5file.keys()) == {'x_vs_y'}
+
+    # the archive file lost its slices and carries different names, forcing a
+    # recomputation while the old .h5 (with the /x_vs_y group) is still present
+    edited = archive.data.m_to_dict(with_root_def=True)
+    edited['parameter_names'] = ['alpha', 'beta']
+    edited['parameter_slices'] = []
+    edited_file = upload_dir / 'boss.archive.json'
+    edited_file.write_text(json.dumps({'data': edited}))
+
+    edited_archive = parse(str(edited_file))[0]
+    normalize_all(edited_archive)
+
+    with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
+        assert set(h5file.keys()) == {'alpha_vs_beta'}
 
 
 @pytest.mark.parametrize(
@@ -196,7 +287,7 @@ def test_analysis_config_sets_names(
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
         assert_h5web_group(
             h5file,
-            '/slice_0',
+            '/phi_vs_psi',
             title='phi vs psi',
             long_names={'parameters_x': 'phi', 'parameters_y': 'psi'},
         )
@@ -250,10 +341,11 @@ def test_name_count_mismatch_warns(
     ]
     assert warnings, 'expected a slice-count mismatch warning'
 
+    # the mismatch aborts the refresh, so the group keeps its original name
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
         assert_h5web_group(
             h5file,
-            '/slice_0',
+            '/x_vs_y',
             title='x vs y',
             long_names={'parameters_x': 'x', 'parameters_y': 'y'},
         )
@@ -268,11 +360,11 @@ def test_real_boss_compute(upload_dir, assert_h5web_group):
     data = archive.data
     assert len(data.parameter_slices) == 1
     with h5py.File(upload_dir / 'boss.h5', 'r') as h5file:
-        assert h5file['/slice_0/fit'].shape[1:] == (50, 50)
-        assert h5file['/slice_0/fit'].shape[0] == h5file['/slice_0/iteration'].shape[0]
+        assert h5file['/x_vs_y/fit'].shape[1:] == (50, 50)
+        assert h5file['/x_vs_y/fit'].shape[0] == h5file['/x_vs_y/iteration'].shape[0]
         assert_h5web_group(
             h5file,
-            '/slice_0',
+            '/x_vs_y',
             title='x vs y',
             long_names={'parameters_x': 'x', 'parameters_y': 'y'},
         )

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -16,35 +16,49 @@ from nomad_parser_plugin_boss.schema_packages.schema_package import (
     slice_group_names,
 )
 
+# Unique names: needed by the map/metamorphic tests, whose `names.index(...)`
+# oracle is ambiguous under duplicates.
 parameter_names = st.lists(
     st.text(min_size=1, max_size=12), min_size=2, max_size=8, unique=True
 )
+# Names that may repeat: for the group-name uniqueness property, which must
+# hold even when parameters share a name.
+parameter_names_maybe_duplicated = st.lists(
+    st.text(min_size=1, max_size=12), min_size=2, max_size=8
+)
 
 
-def test_sanitize_h5_name():
-    # path separator, reference marker and whitespace runs collapse to '_'
-    assert sanitize_h5_name('phi') == 'phi'
-    assert sanitize_h5_name('a/b') == 'a_b'
-    assert sanitize_h5_name('a#b') == 'a_b'
-    assert sanitize_h5_name('spin  up') == 'spin_up'
-    assert sanitize_h5_name(' theta ') == 'theta'
-    # names with no usable characters collapse to empty
-    assert sanitize_h5_name('/') == ''
-    assert sanitize_h5_name('   ') == ''
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        ('phi', 'phi'),
+        ('a/b', 'a_b'),  # path separator
+        ('a#b', 'a_b'),  # reference-fragment marker
+        ('spin  up', 'spin_up'),  # whitespace run
+        (' theta ', 'theta'),  # surrounding whitespace stripped
+        ('/', ''),  # no usable characters
+        ('   ', ''),
+    ],
+)
+def test_sanitize_h5_name(raw, expected):
+    assert sanitize_h5_name(raw) == expected
 
 
-def test_slice_group_names():
-    # groups are named after the compared parameters, in generate_slices order
-    assert slice_group_names(['a', 'b', 'c']) == ['a_vs_b', 'a_vs_c', 'b_vs_c']
-    # a name that sanitizes to empty falls back to the indexed slice name
-    assert slice_group_names(['/', 'b']) == ['slice_0']
-    # names that sanitize to the same component would collide, so the
-    # duplicated group names are disambiguated with the slice index
-    assert slice_group_names(['x/y', 'x#y', 'z']) == [
-        'x_y_vs_x_y',
-        'x_y_vs_z_1',
-        'x_y_vs_z_2',
-    ]
+@pytest.mark.parametrize(
+    ('names', 'expected'),
+    [
+        # named after the compared parameters, in generate_slices order
+        (['a', 'b', 'c'], ['a_vs_b', 'a_vs_c', 'b_vs_c']),
+        # a name that sanitizes to empty falls back to the indexed slice name
+        (['/', 'b'], ['slice_0']),
+        # names sanitizing to the same component collide -> disambiguated
+        (['x/y', 'x#y', 'z'], ['x_y_vs_x_y', 'x_y_vs_z_1', 'x_y_vs_z_2']),
+        # duplicate parameter names collide the same way and stay unique
+        (['a', 'a', 'b'], ['a_vs_a', 'a_vs_b_1', 'a_vs_b_2']),
+    ],
+)
+def test_slice_group_names(names, expected):
+    assert slice_group_names(names) == expected
 
 
 def test_h5web_attribute_map():
@@ -71,23 +85,21 @@ def test_h5web_attribute_map():
     assert attribute_map['/a_vs_b/uncertainty']['units'] == 'eV'
 
 
-@given(names=parameter_names)
+@given(names=parameter_names_maybe_duplicated)
 def test_slice_group_names_properties(names):
     """
     Hypothesis property test for `slice_group_names` over arbitrary lists of
-    2-8 unique names.
+    2-8 names, duplicates allowed. The count (C(n,2)) is structural and pinned
+    by the example tests; generation targets the two invariants that adversarial
+    input can break, including parameters that share a name:
 
-    Predicates, for `names` of length n:
-      G1: exactly C(n,2) group names are produced.
-      G2: every group name is HDF5-path-safe: non-empty and free of '/',
-          '#', and whitespace (they are used directly as path components).
-      G3: the group names are unique (no two slices share a group), which
-          adversarial sanitization collisions must not violate.
+      G2: every group name is HDF5-path-safe -- non-empty and free of '/', '#',
+          and whitespace, since it is used directly as a path component.
+      G3: the group names are unique, even when sanitization collisions or
+          duplicate parameter names would otherwise produce the same name.
     """
     group_names = slice_group_names(names)
-    n = len(names)
 
-    assert len(group_names) == n * (n - 1) // 2  # G1
     for group_name in group_names:
         assert group_name  # G2
         assert not re.search(r'[\s/#]', group_name)  # G2


### PR DESCRIPTION
Follow-up to #73.

Each 2D parameter-space slice was stored in an HDF5 group named
`slice_0`, `slice_1`, ... so the H5Web breadcrumb and inspect tree read
`boss.h5 > slice_0` and only the group `title` attribute revealed which
parameters a slice compared. This names each group after the two
compared parameters (`phi_vs_psi`), so the tree itself reflects what is
plotted.

## Changes

- Add `sanitize_h5_name` (make a name path-safe: collapse `/`, `#`, and
  whitespace) and `slice_group_names` (one `'{x}_vs_{y}'` group per slice
  in `generate_slices` order, with a `slice_{index}` fallback for names
  that sanitize to empty and index-based disambiguation so names stay
  unique). These are the single source of truth consumed by
  `h5web_attribute_map` and `_compute_pes`.
- On an ELN edit of `parameter_names`, `refresh_h5web_labels` now renames
  the groups with a metadata-only `h5py` move (no data copy) and rewrites
  the affected `HDF5Reference` values, so the tree, title, and axis
  labels all follow the edit without recomputing the fits. Legacy
  `slice_N` groups migrate on the next normalization.
- `_compute_pes` now starts from a clean `.h5` on recomputation, so a
  rebuild under different names cannot leave a stale group behind (found
  while verifying a reprocess against the running server).

## Tests

18 pass (was 14). New: `sanitize_h5_name`/`slice_group_names` unit tests;
a `slice_group_names` property test (path-safety + uniqueness under
arbitrary names); the metamorphic map test now aligns entries
positionally since group keys encode the names; the ELN-edit test
asserts the group move and reference rewrite with the fit data
preserved; and a recompute-clears-stale-groups regression test.

Verified end-to-end on a running Oasis: recompute yields a single clean
group, and editing names renames the group in place without recomputing.