### PR TITLE
Migrate PES computation onto aalto-boss's Mesh API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ analysis entry persists and user edits win. See
 
 ## ⚠️ Important Dependency Note
 
-**Temporary Workaround**: This plugin requires `aalto-boss>=1.12.0`, which depends on `GPy>=1.13.1`. GPy has a hard constraint of `scipy<=1.12.0`, which conflicts with newer versions of `pymatgen` (>=2025.10.7) that require `scipy>=1.13.0`.
+**Temporary Workaround**: This plugin requires `aalto-boss>=1.15.1`, which depends on `GPy>=1.13.1`. GPy has a hard constraint of `scipy<=1.12.0`, which conflicts with newer versions of `pymatgen` (>=2025.10.7) that require `scipy>=1.13.0`. (This still holds on the latest aalto-boss; it also pins `matplotlib<3.9`.)
 
 **Current solution**: In deployments that also install `pymatgen` (e.g. a NOMAD distribution), constrain `pymatgen<2025.10.7` in that downstream project's dependencies to maintain compatibility. This constraint lives outside this repository and should be removed once GPy updates to support `scipy>=1.13.0`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "nomad-lab>=1.3.0",
     "nomad-measurements>=1.3.3",
     "python-magic-bin; sys_platform == 'win32'",
-    "aalto-boss>=1.12.0",
+    "aalto-boss>=1.15.1",
     "PyYAML",
 ]
 

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -463,13 +463,10 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
             for iteration in iteration_procedure:
                 mesh.fix_dim_preset(res, 'min', itr=int(iteration))
                 model = res.reconstruct_model(int(iteration))
-                # bind model per iteration; evaluate_func returns a 1-tuple
-                (mean,) = mesh.evaluate_func(lambda X, m=model: m.predict(X)[0])
-                (std,) = mesh.evaluate_func(
-                    lambda X, m=model: np.sqrt(m.predict(X)[1])
-                )
+                # one predict pass; evaluate_func splits the (mean, variance) tuple
+                mean, variance = mesh.evaluate_func(lambda X, m=model: m.predict(X))
                 fit_slices.append(np.asarray(mean))
-                uncertainty_slices.append(np.asarray(std))
+                uncertainty_slices.append(np.sqrt(np.asarray(variance)))
 
             self.parameter_slices.append(ParameterSpaceSlice())
 

--- a/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
+++ b/src/nomad_parser_plugin_boss/schema_packages/schema_package.py
@@ -402,6 +402,7 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
         import os
 
         from boss.bo.results import BOResults
+        from boss.pp.mesh import Mesh
 
         # Resolve via raw_file so it works in both server and client contexts
         with archive.m_context.raw_file(self.data_file) as data_file_handle:
@@ -445,36 +446,37 @@ class ELNBOSSAnalysis(PotentialEnergySurfaceFit, EntryData, PlotSection):
 
         iteration_procedure = np.arange(iter_no, 0, -1)
 
-        # All parameters not in the slice are fixed to the global-minimum point
-        x_default = np.atleast_2d(res.select('x_glmin', iter_no))
-
         group_names = slice_group_names(self.parameter_names)
         for parameter_counter, rank in enumerate(generate_slices(len(bounds))):
             main_rank, upper_rank = rank
             group = group_names[parameter_counter]
-            mu_all_slices, var_all_slices = [], []
+            fit_slices, uncertainty_slices = [], []
 
-            # Query points on the 2D slice grid, built directly instead of via
-            # PPMain/build_query_points, whose pp_model_slice indexing changed
-            # between aalto-boss releases
-            x_grid, y_grid = np.meshgrid(
-                compute_parameters(main_rank), compute_parameters(upper_rank)
+            # BOSS' Mesh builds the 2D slice grid over the two active dimensions
+            # and fixes the rest to the global minimum (the 'min' preset resolves
+            # to select('x_glmin')), replacing the hand-rolled query grid.
+            mesh = Mesh(
+                res.bounds,
+                active_dims=[main_rank, upper_rank],
+                grid_pts=no_grid_points,
             )
-            X = np.tile(x_default, (no_grid_points**2, 1))
-            X[:, main_rank] = x_grid.ravel()
-            X[:, upper_rank] = y_grid.ravel()
-
             for iteration in iteration_procedure:
-                mu, var = res.reconstruct_model(iteration).predict(X)
-                mu_all_slices.append(mu.reshape(no_grid_points, no_grid_points))
-                var_all_slices.append(var.reshape(no_grid_points, no_grid_points))
+                mesh.fix_dim_preset(res, 'min', itr=int(iteration))
+                model = res.reconstruct_model(int(iteration))
+                # bind model per iteration; evaluate_func returns a 1-tuple
+                (mean,) = mesh.evaluate_func(lambda X, m=model: m.predict(X)[0])
+                (std,) = mesh.evaluate_func(
+                    lambda X, m=model: np.sqrt(m.predict(X)[1])
+                )
+                fit_slices.append(np.asarray(mean))
+                uncertainty_slices.append(np.asarray(std))
 
             self.parameter_slices.append(ParameterSpaceSlice())
 
             archive_prefix = f'data.parameter_slices[{parameter_counter}]'
             for dataset, data in (
-                ('fit', np.array(mu_all_slices)),
-                ('uncertainty', np.sqrt(np.array(var_all_slices))),
+                ('fit', np.array(fit_slices)),
+                ('uncertainty', np.array(uncertainty_slices)),
                 ('iteration', iteration_procedure),
                 ('parameters_x', np.array(compute_parameters(main_rank))),
                 ('parameters_y', np.array(compute_parameters(upper_rank))),


### PR DESCRIPTION
Replace the hand-rolled query-grid construction in `_compute_pes` with
`boss.pp.mesh.Mesh`, the data-level API added in aalto-boss's 1.14
postprocessing refactor, and bump the pin to `aalto-boss>=1.15.1`.

## Why

The previous code built the 2D slice grid by hand (`np.meshgrid` + `np.tile`,
fixing the non-slice dimensions to `res.select('x_glmin')`) and called
`res.reconstruct_model(itr).predict(X)` directly. That existed only because the
old `PPMain`/`build_query_points` path used a 1-based `pp_model_slice` whose
indexing convention changed between releases (the bug CI caught earlier).

`Mesh` does exactly this, documented and 0-based:

```python
mesh = Mesh(res.bounds, active_dims=[i, j], grid_pts=50)
mesh.fix_dim_preset(res, 'min', itr=iteration)   # 'min' resolves to select('x_glmin')
mean = mesh.evaluate_func(lambda X: model.predict(X)[0])[0]
std  = mesh.evaluate_func(lambda X: np.sqrt(model.predict(X)[1]))[0]
```

`active_dims` is 0-based, removing the `pp_model_slice` ±1 hazard.
`reconstruct_model` is kept (it is the only way to get the model object and is
stable across 1.12→1.15); `Mesh` takes over the fragile grid/indexing.

## Equivalence

The generated `boss.h5` is **byte-identical** to the previous output on
`tests/data/boss.rst` — `fit`, `uncertainty`, `iteration`, and both axis arrays
are `array_equal` (max abs diff 0.0), verified against a reference captured from
aalto-boss 1.12.0. Full suite (incl. the slow real-BOSS test) green; ruff clean.

## Not changed

The GPy `scipy<=1.12` constraint — and thus the downstream `pymatgen<2025.10.7`
pin — persists on the latest aalto-boss, so it is unchanged here. The bump adds a
transitive `matplotlib<3.9` constraint (no conflict with nomad-FAIR, which pins
no matplotlib bound).