### PR TITLE
Migrate devcontainer ruff feature to devcontainers-extra

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/python:1-3.9-bookworm",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/ruff:1": {}
+    "ghcr.io/devcontainers-extra/features/ruff:2": {}
   },
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},


### PR DESCRIPTION
Supersedes #71.

`devcontainers-contrib` is deprecated — the original creator deleted the account,
and the maintained community successor is `devcontainers-extra`. So instead of
bumping the feature on the dead source (as Dependabot #71 proposes), this repoints
the ruff devcontainer feature to `ghcr.io/devcontainers-extra/features/ruff:2`.

Devcontainer-only change: affects only VS Code devcontainer users; no impact on CI,
packaging, or the shipped plugin.